### PR TITLE
Factor out captures and terminals

### DIFF
--- a/examples/src/ExampleServant.hs
+++ b/examples/src/ExampleServant.hs
@@ -16,7 +16,7 @@ import           Servant
 import           Rowdy.Servant
 
 toServant "MyApi" $ do
-    let unit = Type (Proxy @())
+    let unit = SomeType (Proxy @())
     "users" // do
         get unit
         -- need to add reqBody support

--- a/rowdy/package.yaml
+++ b/rowdy/package.yaml
@@ -18,6 +18,7 @@ dependencies:
 - base >= 4.7 && < 5
 - mtl
 - dlist
+- containers
 
 library:
   source-dirs: src

--- a/rowdy/src/Rowdy/Class.hs
+++ b/rowdy/src/Rowdy/Class.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE FlexibleContexts #-}
+-- {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE AllowAmbiguousTypes  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveFunctor        #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE GADTs                #-}
+-- {-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+
+module Rowdy.Class where
+
+import Data.String
+-- import Control.Monad.State
+
+data HttpVerb = Get | Put | Post | Delete
+    deriving Show
+
+data SubsiteDef = SubsiteDef
+
+class Monad m => Endpoint m where
+    record :: m ()
+
+class Endpoint m => Verb m where
+    verb :: HttpVerb -> m ()
+
+class Endpoint m => Subsite m where
+    forward :: SubsiteDef -> m ()
+
+class PathPiece a m where
+    enlist :: a -> m ()
+
+class HasPath x m where
+    addPath :: x -> m ()
+    getPath :: m [x]
+
+instance HasPath String m => PathPiece String m where
+    enlist = addPath
+
+(//) :: Monad m => PathPiece a m => Endpoint m => a -> m () -> m ()
+a // m = do
+    enlist a
+    m
+
+infixr 7 //
+
+get, put, post, delete :: Verb m => m ()
+get = verb Get
+put = verb Put
+post = verb Post
+delete = verb Delete
+
+example :: (HasPath String m, Verb m, Subsite m) => m ()
+example = do
+    "users" // "get" // "wrecked" // post
+    "tagless" // do
+        "final" // do
+            get
+    "fuck" // forward SubsiteDef


### PR DESCRIPTION
This PR will make it easier to fully support the various routing libraries.

Yesod can be fully and easily supported with a concrete datatype, as the routing isn't extensible.

Servant, on the other hand, will need something more complex.